### PR TITLE
fix: mark import as 'Completed' after data is sent to frontend

### DIFF
--- a/apps/api/src/app/review/usecases/start-process/start-process.usecase.ts
+++ b/apps/api/src/app/review/usecases/start-process/start-process.usecase.ts
@@ -41,19 +41,23 @@ export class StartProcess {
       });
     }
 
-    // if template destination has callbackUrl then start sending data to the callbackUrl
-    if (destination) {
-      uploadInfo = await this.uploadRepository.findOneAndUpdate(
-        { _id: _uploadId },
-        { status: UploadStatusEnum.PROCESSING }
-      );
-    } else {
-      // else complete the upload process
+    // if destination is frontend or not defined then complete the upload process
+    if (
+      !destination ||
+      (uploadInfo._templateId as unknown as TemplateEntity).destination === DestinationsEnum.FRONTEND
+    ) {
       uploadInfo = await this.uploadRepository.findOneAndUpdate(
         { _id: _uploadId },
         { status: UploadStatusEnum.COMPLETED }
       );
+    } else {
+      // if template destination has callbackUrl then start sending data to the callbackUrl
+      uploadInfo = await this.uploadRepository.findOneAndUpdate(
+        { _id: _uploadId },
+        { status: UploadStatusEnum.PROCESSING }
+      );
     }
+
     this.queueService.publishToQueue(QueuesEnum.END_IMPORT, {
       uploadId: _uploadId,
       destination: destination,


### PR DESCRIPTION


BUG #730 


### **Fix Import Status Not Updating to 'Completed' After Data Sent to Frontend**

**Issue:**
- The import status was incorrectly remaining as "Processing" even after the data was successfully sent to the frontend application.

**Solution:**
- Updated the logic to ensure that once the data import is completed and sent to the frontend, the import status is properly marked as "Completed."

**Steps to Reproduce:**
1. Create or update an import with the destination set to Frontend.
2. Complete the import process and close the import widget.
3. Check the import log in the Analytics section; it incorrectly shows the status as "Processing."

**Expected Behavior:**
- The import status should be updated to "Completed" once the data is sent to the frontend.

**Changes Made:**
- Modified the import status update logic to correctly reflect the completed status for imports directed to the frontend.

**Testing:**
- Verified that the status now changes to "Completed" after the import is sent to the frontend as expected.
