### PR TITLE
feat/Password validtion added to prevent security issue with bcrypt hashing

### DIFF
--- a/apps/api/src/app/auth/dtos/register-user.dto.ts
+++ b/apps/api/src/app/auth/dtos/register-user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsString, IsEmail, IsOptional } from 'class-validator';
+import { IsDefined, IsString, IsEmail, IsOptional, MaxLength } from 'class-validator';
 
 export class RegisterUserDto {
   @ApiProperty({
@@ -28,6 +28,7 @@ export class RegisterUserDto {
   })
   @IsString()
   @IsDefined()
+  @MaxLength(70)
   password: string;
 
   @ApiProperty({

--- a/apps/api/src/app/auth/dtos/reset-password.dto.ts
+++ b/apps/api/src/app/auth/dtos/reset-password.dto.ts
@@ -1,9 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsString, IsUUID } from 'class-validator';
+import { IsDefined, IsString, IsUUID, MaxLength } from 'class-validator';
 
 export class ResetPasswordDto {
   @IsString()
   @IsDefined()
+  @MaxLength(70)
   @ApiProperty({
     description: 'New password of the user',
   })


### PR DESCRIPTION
This PR addresses issue [#864](https://github.com/implerhq/impler.io/issues/864)

**Changes maded:**

- Added password length validation of 70 while register and password-reset flows.