### PR TITLE
Fix/no default selected project on relogin

### DIFF
--- a/apps/api/src/app/project/usecases/delete-project/delete-project.usecase.ts
+++ b/apps/api/src/app/project/usecases/delete-project/delete-project.usecase.ts
@@ -1,14 +1,21 @@
 import { Injectable } from '@nestjs/common';
-import { ProjectRepository } from '@impler/dal';
+import { ProjectRepository, EnvironmentRepository } from '@impler/dal';
 import { DocumentNotFoundException } from '@shared/exceptions/document-not-found.exception';
 
 @Injectable()
 export class DeleteProject {
-  constructor(private projectRepository: ProjectRepository) {}
+  constructor(
+    private projectRepository: ProjectRepository,
+    private environmentRepository: EnvironmentRepository
+  ) {}
 
   async execute(_projectId: string, _userId: string) {
     const project = await this.projectRepository.findOne({ _id: _projectId, _userId });
     if (!project) throw new DocumentNotFoundException('Project', _projectId);
+
+    await this.environmentRepository.delete({
+      _projectId: project._id,
+    });
 
     return this.projectRepository.delete({ _id: _projectId });
   }

--- a/apps/api/src/migrations/delete-environment-for-deleted-project/delete-environment-for-deleted-project.ts
+++ b/apps/api/src/migrations/delete-environment-for-deleted-project/delete-environment-for-deleted-project.ts
@@ -1,0 +1,101 @@
+/**
+ * Migration script for deleting environments associated with deleted projects.
+ *
+ * This migration is designed to clean up environment documents that are still
+ * associated with projects that have already been deleted. In older versions
+ * of the system, if a project was deleted, the corresponding environment
+ * documents were not automatically deleted. This issue has been fixed in
+ * newer versions, but for older users, we need to run this migration to
+ * ensure that any environments associated with deleted projects are properly removed.
+ */
+
+import '../../config';
+import { AppModule } from '../../app.module';
+
+import { NestFactory } from '@nestjs/core';
+import { EnvironmentRepository } from '@impler/dal';
+export async function run() {
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+
+  const environmentRepository = new EnvironmentRepository();
+  const deletedProjectsInEnvironments = await environmentRepository.aggregate([
+    {
+      $lookup: {
+        from: 'project',
+        localField: '_projectId',
+        foreignField: '_id',
+        as: 'project',
+      },
+    },
+    {
+      $match: {
+        project: {
+          $size: 0,
+        },
+      },
+    },
+    {
+      $unwind: {
+        path: '$apiKeys',
+        preserveNullAndEmptyArrays: false,
+      },
+    },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'apiKeys._userId',
+        foreignField: '_id',
+        as: 'userInfo',
+      },
+    },
+    {
+      $unwind: {
+        path: '$userInfo',
+        preserveNullAndEmptyArrays: true,
+      },
+    },
+    {
+      $project: {
+        _id: 1,
+        _projectId: 1,
+        apiKeys: {
+          _userId: '$apiKeys._userId',
+          // key: "$apiKeys.key",
+          user: {
+            firstName: '$userInfo.firstName',
+            lastName: '$userInfo.lastName',
+            email: '$userInfo.email',
+          },
+        },
+      },
+    },
+    {
+      $group: {
+        _id: '$_id',
+        _projectId: {
+          $first: '$_projectId',
+        },
+        apiKeys: {
+          $push: '$apiKeys',
+        },
+      },
+    },
+  ]);
+
+  const deletedProjectIdInEnvironment = deletedProjectsInEnvironments.map((deletedProjects) => deletedProjects._id);
+
+  if (deletedProjectIdInEnvironment.length > 0) {
+    await environmentRepository.deleteMany({
+      _id: { $in: deletedProjectIdInEnvironment },
+    });
+    console.log(`end migration - deleted ${deletedProjectIdInEnvironment.length} environments.`);
+  } else {
+    console.log('end migration - No environments found to delete.');
+  }
+
+  app.close();
+  process.exit(0);
+}
+run();

--- a/apps/web/hooks/useProject.tsx
+++ b/apps/web/hooks/useProject.tsx
@@ -96,6 +96,10 @@ export function useProject() {
           const remainingProjects = projects?.filter((project) => project._id !== deletedProjectId);
           if (remainingProjects?.length) {
             switchProject(remainingProjects[0]._id);
+            setProfileInfo({
+              ...profileInfo,
+              _projectId: remainingProjects[0]._id,
+            });
           } else {
             replace(ROUTES.HOME);
           }


### PR DESCRIPTION
**This MR fixes issue -**

This merge request fixes an issue where, upon deleting the currently selected project, logging out, and then logging back in, no project is selected by default. Instead, the user is presented with the "No Project Selected" state and has to manually select a project.
 
**Changes Made:**

- Added a Mongoose delete query to automatically delete the environment related to the project.
- When a user deletes a project, the next available project will be selected and stored in the context.
- Written a migration script for removing the corresponding environment for previous users.