### PR TITLE
feat: Added greedy option for skipEmptyLines to handle blank lines an…

### DIFF
--- a/apps/api/src/app/review/usecases/do-review/base-review.usecase.ts
+++ b/apps/api/src/app/review/usecases/do-review/base-review.usecase.ts
@@ -405,7 +405,7 @@ export class BaseReview {
         validRecords = 0;
       Papa.parse(csvFileStream, {
         dynamicTyping: false,
-        skipEmptyLines: true,
+        skipEmptyLines: 'greedy',
         step: (results: Papa.ParseStepResult<any>) => {
           totalRecords++;
           const record = results.data;
@@ -593,7 +593,7 @@ export class BaseReview {
 
         Papa.parse(csvFileStream, {
           dynamicTyping: false,
-          skipEmptyLines: true,
+          skipEmptyLines: 'greedy',
           step: (results: Papa.ParseStepResult<any>) => {
             recordsCount++;
             const record = results.data;

--- a/apps/api/src/app/shared/services/file/file.service.ts
+++ b/apps/api/src/app/shared/services/file/file.service.ts
@@ -185,7 +185,7 @@ export class CSVFileService2 {
       parse(fileContent, {
         ...(options || {}),
         dynamicTyping: false,
-        skipEmptyLines: true,
+        skipEmptyLines: 'greedy',
         step: function (results) {
           rows++;
           if (Array.isArray(results.data)) {

--- a/apps/api/src/app/upload/usecases/get-preview-rows/get-preview-rows.usecase.ts
+++ b/apps/api/src/app/upload/usecases/get-preview-rows/get-preview-rows.usecase.ts
@@ -12,7 +12,7 @@ export class GetPreviewRows {
     return new Promise((resolve, reject) => {
       Papa.parse(csvFileStream, {
         dynamicTyping: false,
-        skipEmptyLines: true,
+        skipEmptyLines: 'greedy',
         preview: 15,
         complete({ data }) {
           resolve(data);


### PR DESCRIPTION
Description:
The skipEmptyLines option in Papa Parse was previously set to true, which only skips fully blank lines. However, lines containing just commas (e.g., ,,,,, ,,,,,) were not being handled correctly and would still be parsed as valid, non-empty lines, causing issues in CSV parsing and was causing empty records.

Changes Made:
Added the 'greedy' option to the skipEmptyLines configuration.
This update ensures that both blank lines and lines containing only commas (e.g., ,,,,, ,,,,,) are treated as empty and skipped during parsing, improving how CSV files are handled.