### PR TITLE
Potential fix for code scanning alert no. 92: Prototype-polluting assignment

### DIFF
--- a/libs/services/src/rss-xml/rssxml.service.ts
+++ b/libs/services/src/rss-xml/rssxml.service.ts
@@ -498,6 +498,12 @@ export class RSSXMLService {
   }
 
   async setValue(obj: Record<string, any>, path: string[], value: any, attributes?: any): Promise<void> {
+    // Validate path to prevent prototype pollution
+    const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
+    if (path.some(key => forbiddenKeys.includes(key))) {
+      throw new Error('Invalid path: contains forbidden keys');
+    }
+
     let current = obj;
 
     // Navigate to parent


### PR DESCRIPTION
Potential fix for [https://github.com/implerhq/impler.io/security/code-scanning/92](https://github.com/implerhq/impler.io/security/code-scanning/92)

To fix the issue, we need to prevent the use of special keys like `__proto__`, `constructor`, and `prototype` in the `path` array. This can be achieved by validating each key in the `path` array before using it to navigate or modify the `obj` object. If any key matches one of these special values, the function should throw an error or ignore the operation.

The best way to fix this is to add a validation step for `path` at the beginning of the `setValue` function. This ensures that no special keys are used, preventing prototype pollution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
